### PR TITLE
feat: add download of latest release of rpi-client-app

### DIFF
--- a/.github/workflows/package-deb.yaml
+++ b/.github/workflows/package-deb.yaml
@@ -1,16 +1,23 @@
 name: Package Deb
 
 on:
-  push:
-    paths:
-      - '**.deb'
+  repository_dispatch:
+    types: [rpi-client-release]
 
 jobs:
   package:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Download release
+        uses: robinraju/release-downloader@v1.11
+        with:
+          repo: 'presentium/rpi-client-app'
+          latest: true
+          fileName: '*.deb'
 
       - name: Import GPG key
         run: echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 --decode | gpg --import


### PR DESCRIPTION
### Description
Adds a step in action to download the latest release from rpi-client-app to get the .deb package necessary for the package build

### Linked Issues
ref #1  

### Additional context
trigger event changed to repository_dispatch with a custom event name. Will be called by rpi-client-app repo when a new release is published
